### PR TITLE
Fix PNWiki schematic fetching to resolve most substance images

### DIFF
--- a/psychotropic/providers/pnwiki.py
+++ b/psychotropic/providers/pnwiki.py
@@ -1,5 +1,7 @@
+import asyncio as aio
 from io import BytesIO
 from operator import itemgetter
+from urllib.parse import quote
 
 import httpx
 from PIL import Image
@@ -7,25 +9,29 @@ from PIL import Image
 
 PNWIKI_URL = 'https://psychonautwiki.org/w/'
 
+PNWIKI_MW_API_URL = 'https://psychonautwiki.org/w/api.php'
+
 PNWIKI_API_URL = 'https://api.psychonautwiki.org/'
 
 
 class PNWikiAPIClient(httpx.AsyncClient):
     def __init__(self, *args, **kwargs):
         super().__init__(
+            *args,
             base_url=PNWIKI_API_URL,
             headers={
                 "accept-type": "application/json",
                 "content-type": "application/json"
             },
-            *args, **kwargs
+            **kwargs,
         )
-    
+
     async def post_graphql(self, query, *args, **kwargs):
         return await self.post(
+            *args,
             url='/',
             json={'query': query},
-            *args, **kwargs
+            **kwargs,
         )
 
 
@@ -39,7 +45,7 @@ async def list_substances():
     """
     async with PNWikiAPIClient() as client:
         r = await client.post_graphql(query)
-    
+
     return list(map(
         itemgetter('name'),
         r.json()['data']['substances']
@@ -68,20 +74,48 @@ async def get_substance(query, **kwargs):
     return substances[0] if len(substances) else None
 
 
-def get_schematic_url(substance, width=500):
-    return f'{PNWIKI_URL}thumb.php?f={substance}.svg&width={width}'
+async def get_page_images(substance_names):
+    """Batch-query the MediaWiki API to get the primary image filename
+    for each substance page.
 
+    Returns a dict mapping substance name to its SVG filename, or None
+    if no page image was found.
+    """
+    result = {}
 
-async def get_schematic_image(substance, width=500, background_color=None):
-    """Get a PIL `Image` of a given substance by fetching its schematic on
-    PNWiki. Return `None` if no schematic is found."""
     async with httpx.AsyncClient() as client:
-        r = await client.get(get_schematic_url(substance, width))
+        # MediaWiki API supports up to 50 titles per request
+        for i in range(0, len(substance_names), 50):
+            batch = substance_names[i:i + 50]
+            titles = "|".join(batch)
 
-    if r.status_code != 200:
-        return None
+            r = await client.get(PNWIKI_MW_API_URL, params={
+                "action": "query",
+                "titles": titles,
+                "prop": "pageimages",
+                "format": "json",
+            })
 
-    image = Image.open(BytesIO(r.content))
+            pages = r.json().get("query", {}).get("pages", {})
+            for page in pages.values():
+                title = page.get("title")
+                pageimage = page.get("pageimage")
+                if title and pageimage:
+                    result[title] = pageimage
+
+    return result
+
+
+def get_schematic_url(filename, width=500):
+    return (
+        f'{PNWIKI_URL}thumb.php'
+        f'?f={quote(filename)}&width={width}'
+    )
+
+
+def _parse_schematic_image(data, background_color=None):
+    """Parse raw image bytes into a PIL Image with optional background."""
+    image = Image.open(BytesIO(data))
 
     if background_color:
         background = Image.new("RGB", image.size, background_color)
@@ -89,3 +123,44 @@ async def get_schematic_image(substance, width=500, background_color=None):
         image = background
 
     return image
+
+
+async def get_schematic_image(filename, width=500, background_color=None):
+    """Get a PIL `Image` of a substance by fetching its schematic on
+    PNWiki. `filename` is the actual SVG filename from the wiki.
+    Return `None` if no schematic is found."""
+    async with httpx.AsyncClient() as client:
+        r = await client.get(get_schematic_url(filename, width))
+
+    if r.status_code != 200:
+        return None
+
+    return _parse_schematic_image(r.content, background_color)
+
+
+async def fetch_schematic_images(svg_map, width=500, background_color=None):
+    """Batch-fetch schematic images for multiple substances concurrently.
+
+    `svg_map` is a dict mapping substance name to SVG filename.
+    Returns a dict mapping substance name to PIL Image (or None on failure).
+    """
+    results = {}
+
+    async def _fetch_one(client, name, filename):
+        try:
+            r = await client.get(get_schematic_url(filename, width))
+        except httpx.HTTPError:
+            results[name] = None
+            return
+        if r.status_code != 200:
+            results[name] = None
+            return
+        results[name] = _parse_schematic_image(r.content, background_color)
+
+    async with httpx.AsyncClient() as client:
+        await aio.gather(*(
+            _fetch_one(client, name, filename)
+            for name, filename in svg_map.items()
+        ))
+
+    return results

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371 }
 wheels = [


### PR DESCRIPTION
- Use MediaWiki pageimages API to resolve actual SVG filenames instead of guessing from substance names (fixes missing schematics)
- Batch-fetch all schematic images concurrently over a single client